### PR TITLE
Removes prefix of sample secret_access_key

### DIFF
--- a/.env.private.sample
+++ b/.env.private.sample
@@ -1,5 +1,5 @@
 # Private environment variable overrides. Will not be committed.
 AWS_ACCESS_KEY_ID="AKIAxxx"
-AWS_SECRET_ACCESS_KEY="OPXPyYOUR_SECRET_KEY"
+AWS_SECRET_ACCESS_KEY="YOUR_SECRET_KEY"
 ENVIRONMENT="test"
 


### PR DESCRIPTION
Removes the prefix of the secret_access_key that is in the sample environment file 