### PR TITLE
Disable Rubocop warnings about Trailing Comma's in Array Literals and Hash Literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,3 +105,9 @@ Style/EvalWithLocation:
 
 Style/PerlBackrefs:
   Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false


### PR DESCRIPTION
Disable Rubocop warnings about Trailing Comma's in Array Literals and Hash Literals